### PR TITLE
Use a version of golangci-lint that supports go 1.21

### DIFF
--- a/.github/workflows/ci_baseline_go_lints.yml
+++ b/.github/workflows/ci_baseline_go_lints.yml
@@ -36,5 +36,5 @@ jobs:
         id: lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: "v1.53"
+          version: "v1.54.2"
           working-directory: ${{inputs.module_base}}


### PR DESCRIPTION
We need it in tsnsrv, guess it's time to see what breaks with it.